### PR TITLE
Restore Flask package structure and material utilities

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,37 @@
+import os
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+# Global SQLAlchemy instance that can be imported by the rest of the project
+# Scripts such as ``init_db.py`` and ``fix_material_table.py`` rely on this
+# object being available at ``app.db``.
+db = SQLAlchemy()
+
+
+def create_app(test_config: dict | None = None) -> Flask:
+    """Application factory for the Approver web application.
+
+    The function configures a Flask application instance, initialises the
+    database layer and ensures that the ORM models are imported so that SQLAlchemy
+    is aware of them before ``create_all`` is executed by the maintenance
+    scripts.
+    """
+
+    app = Flask(__name__)
+
+    app.config.from_mapping(
+        SQLALCHEMY_DATABASE_URI=os.environ.get("DATABASE_URL", "sqlite:///approver.db"),
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+
+    if test_config:
+        app.config.update(test_config)
+
+    db.init_app(app)
+
+    # Import models so they are registered with SQLAlchemy. Importing inside the
+    # factory avoids circular import issues while keeping the module level
+    # ``db`` instance accessible to callers importing ``app``.
+    from . import models  # noqa: F401  # pylint: disable=unused-import
+
+    return app

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,32 @@
+"""Convenience imports for the ORM models."""
+
+from .. import db
+from .models import (
+    db as _db_instance,
+    KomposisiMaterial,
+    Material,
+    MaterialProduk,
+    Produk,
+    Produksi,
+    RencanaProduksi,
+    StokProduk,
+    TargetPengiriman,
+)
+
+# Ensure that ``db`` exported from this module is the same instance as the one
+# defined in :mod:`app.__init__`. The ``_db_instance`` import will raise an
+# ImportError if the models module is imported before the database is created,
+# providing fast feedback during development.
+assert _db_instance is db
+
+__all__ = [
+    "db",
+    "Produk",
+    "Material",
+    "KomposisiMaterial",
+    "StokProduk",
+    "TargetPengiriman",
+    "RencanaProduksi",
+    "MaterialProduk",
+    "Produksi",
+]

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -1,0 +1,227 @@
+"""Database models for the Approver web application."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import UniqueConstraint
+from sqlalchemy.orm import synonym
+
+from .. import db
+
+
+class TimestampMixin:
+    """Mixin that provides ``created_at`` and ``updated_at`` timestamps."""
+
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )
+
+
+class Produk(TimestampMixin, db.Model):
+    __tablename__ = "produk"
+
+    id = db.Column(db.Integer, primary_key=True)
+    kode = db.Column(db.String(64), unique=True, nullable=True)
+    nama = db.Column(db.String(255), nullable=False)
+    jenis = db.Column(db.String(120), nullable=True)
+    kelompok = db.Column(db.String(120), nullable=True)
+
+    komposisi_material = db.relationship(
+        "KomposisiMaterial",
+        back_populates="produk",
+        cascade="all, delete-orphan",
+        lazy=True,
+    )
+    stok = db.relationship(
+        "StokProduk",
+        back_populates="produk",
+        cascade="all, delete-orphan",
+        lazy=True,
+    )
+    target_pengiriman = db.relationship(
+        "TargetPengiriman",
+        back_populates="produk",
+        cascade="all, delete-orphan",
+        lazy=True,
+    )
+    rencana_produksi = db.relationship(
+        "RencanaProduksi",
+        back_populates="produk",
+        cascade="all, delete-orphan",
+        lazy=True,
+    )
+    material_produk = db.relationship(
+        "MaterialProduk",
+        back_populates="produk",
+        cascade="all, delete-orphan",
+        lazy=True,
+    )
+    produksi = db.relationship(
+        "Produksi",
+        back_populates="produk",
+        cascade="all, delete-orphan",
+        lazy=True,
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<Produk {self.kode or self.id}: {self.nama}>"
+
+
+class Material(TimestampMixin, db.Model):
+    __tablename__ = "material"
+
+    id = db.Column(db.Integer, primary_key=True)
+    kode = db.Column(db.String(64), unique=True, nullable=True)
+    nama = db.Column(db.String(255), nullable=False)
+    satuan = db.Column(db.String(32), nullable=True)
+    # Alias dengan huruf kapital diperlukan oleh beberapa skrip warisan yang
+    # mengakses atribut ``Material.Satuan`` secara langsung.
+    Satuan = synonym("satuan")
+    stok = db.Column(db.Float, default=0, nullable=False)
+    min_stok = db.Column(db.Float, default=0, nullable=False)
+    status = db.Column(db.String(32), default="aktif", nullable=False)
+    jenis = db.Column(db.String(120), nullable=True)
+    kelompok = db.Column(db.String(120), nullable=True)
+
+    komposisi_material = db.relationship(
+        "KomposisiMaterial",
+        back_populates="material",
+        cascade="all, delete-orphan",
+        lazy=True,
+    )
+    material_produk = db.relationship(
+        "MaterialProduk",
+        back_populates="material",
+        cascade="all, delete-orphan",
+        lazy=True,
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<Material {self.kode or self.id}: {self.nama}>"
+
+
+class KomposisiMaterial(TimestampMixin, db.Model):
+    __tablename__ = "komposisi_material"
+    __table_args__ = (
+        UniqueConstraint("produk_id", "material_id", name="uq_komposisi_produk_material"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    produk_id = db.Column(db.Integer, db.ForeignKey("produk.id"), nullable=False)
+    material_id = db.Column(db.Integer, db.ForeignKey("material.id"), nullable=False)
+    persentase = db.Column(db.Float, nullable=True)
+    jumlah_per_pack = db.Column(db.Float, nullable=True)
+    satuan = db.Column(db.String(32), nullable=True)
+
+    produk = db.relationship("Produk", back_populates="komposisi_material")
+    material = db.relationship("Material", back_populates="komposisi_material")
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return (
+            f"<KomposisiMaterial produk={self.produk_id} material={self.material_id} "
+            f"jumlah={self.jumlah_per_pack} {self.satuan}>"
+        )
+
+
+class MaterialProduk(TimestampMixin, db.Model):
+    __tablename__ = "material_produk"
+    __table_args__ = (
+        UniqueConstraint("produk_id", "material_id", name="uq_material_produk"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    produk_id = db.Column(db.Integer, db.ForeignKey("produk.id"), nullable=False)
+    material_id = db.Column(db.Integer, db.ForeignKey("material.id"), nullable=False)
+    jumlah = db.Column(db.Float, nullable=True)
+    satuan = db.Column(db.String(32), nullable=True)
+
+    produk = db.relationship("Produk", back_populates="material_produk")
+    material = db.relationship("Material", back_populates="material_produk")
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return (
+            f"<MaterialProduk produk={self.produk_id} material={self.material_id} "
+            f"jumlah={self.jumlah} {self.satuan}>"
+        )
+
+
+class StokProduk(TimestampMixin, db.Model):
+    __tablename__ = "stok_produk"
+
+    id = db.Column(db.Integer, primary_key=True)
+    produk_id = db.Column(db.Integer, db.ForeignKey("produk.id"), nullable=False)
+    tanggal = db.Column(db.Date, nullable=True)
+    jumlah = db.Column(db.Float, default=0, nullable=False)
+
+    produk = db.relationship("Produk", back_populates="stok")
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<StokProduk produk={self.produk_id} tanggal={self.tanggal} jumlah={self.jumlah}>"
+
+
+class TargetPengiriman(TimestampMixin, db.Model):
+    __tablename__ = "target_pengiriman"
+
+    id = db.Column(db.Integer, primary_key=True)
+    produk_id = db.Column(db.Integer, db.ForeignKey("produk.id"), nullable=False)
+    tanggal = db.Column(db.Date, nullable=True)
+    jumlah = db.Column(db.Float, default=0, nullable=False)
+
+    produk = db.relationship("Produk", back_populates="target_pengiriman")
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<TargetPengiriman produk={self.produk_id} tanggal={self.tanggal} jumlah={self.jumlah}>"
+
+
+class RencanaProduksi(TimestampMixin, db.Model):
+    __tablename__ = "rencana_produksi"
+
+    id = db.Column(db.Integer, primary_key=True)
+    produk_id = db.Column(db.Integer, db.ForeignKey("produk.id"), nullable=False)
+    tanggal_mulai = db.Column(db.Date, nullable=True)
+    tanggal_selesai = db.Column(db.Date, nullable=True)
+    jumlah_karton = db.Column(db.Float, default=0, nullable=False)
+
+    produk = db.relationship("Produk", back_populates="rencana_produksi")
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return (
+            f"<RencanaProduksi produk={self.produk_id} jumlah={self.jumlah_karton} "
+            f"mulai={self.tanggal_mulai} selesai={self.tanggal_selesai}>"
+        )
+
+
+class Produksi(TimestampMixin, db.Model):
+    __tablename__ = "produksi"
+
+    id = db.Column(db.Integer, primary_key=True)
+    produk_id = db.Column(db.Integer, db.ForeignKey("produk.id"), nullable=False)
+    tanggal = db.Column(db.Date, nullable=True)
+    jumlah_karton = db.Column(db.Float, default=0, nullable=False)
+    pack_per_karton = db.Column(db.Integer, default=0, nullable=False)
+
+    produk = db.relationship("Produk", back_populates="produksi")
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return (
+            f"<Produksi produk={self.produk_id} tanggal={self.tanggal} "
+            f"jumlah_karton={self.jumlah_karton}>"
+        )
+
+
+__all__ = [
+    "db",
+    "Produk",
+    "Material",
+    "KomposisiMaterial",
+    "StokProduk",
+    "TargetPengiriman",
+    "RencanaProduksi",
+    "MaterialProduk",
+    "Produksi",
+]

--- a/app/utils/material.py
+++ b/app/utils/material.py
@@ -1,0 +1,180 @@
+"""Utility helpers for working with material data."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Tuple
+
+from flask import current_app
+
+from ..models import (
+    KomposisiMaterial,
+    Material,
+    MaterialProduk,
+    Produk,
+    db,
+)
+
+
+def _clean_cell(value: str | None) -> str:
+    return value.strip() if value else ""
+
+
+def _parse_float(value: str | None) -> float | None:
+    if not value:
+        return None
+
+    normalised = value.replace(".", "").replace(",", ".").replace("%", "").strip()
+    if not normalised:
+        return None
+
+    try:
+        return float(normalised)
+    except ValueError:
+        return None
+
+
+def _resolve_csv_path(filename: str) -> Path:
+    path = Path(filename)
+    if path.is_absolute():
+        return path
+    # CSV files are typically stored alongside the project root.
+    project_root = Path(current_app.root_path).parent
+    return project_root / filename
+
+
+def baca_csv_material(filename: str) -> Tuple[bool, str]:
+    """Import material composition data from a CSV file.
+
+    The CSV structure can vary slightly between exports. The helper is resilient
+    to both the legacy format (with material codes and percentage columns) and
+    the simplified format used by the newer tooling. The function returns a
+    ``(success, message)`` tuple so callers can surface useful error information
+    without needing to raise exceptions.
+    """
+
+    try:
+        csv_path = _resolve_csv_path(filename)
+    except RuntimeError as exc:  # pragma: no cover - defensive
+        return False, str(exc)
+
+    if not csv_path.exists():
+        return False, f"File '{filename}' tidak ditemukan"
+
+    try:
+        with csv_path.open(newline="", encoding="utf-8-sig") as handle:
+            reader = csv.reader(handle, delimiter=";")
+            current_produk: Produk | None = None
+
+            for raw_row in reader:
+                row = [_clean_cell(cell) for cell in raw_row]
+                if not any(row):
+                    # Blank lines are used as separators between produk entries.
+                    current_produk = None
+                    continue
+
+                if row and row[0]:
+                    kode_produk = row[0]
+                    nama_produk = row[1] if len(row) > 1 and row[1] else kode_produk
+
+                    current_produk = Produk.query.filter_by(kode=kode_produk).first()
+                    if current_produk is None:
+                        current_produk = Produk(kode=kode_produk, nama=nama_produk)
+                        db.session.add(current_produk)
+                        db.session.flush()  # ensure the new ID is available
+                    else:
+                        current_produk.nama = nama_produk
+
+                if current_produk is None:
+                    # Material rows must always follow a produk header. If the file
+                    # does not contain a header before material rows we simply skip
+                    # the orphaned entries.
+                    continue
+
+                # Legacy exports contain up to seven columns, newer exports only
+                # five. Extract the known fields defensively.
+                kode_material = row[2] if len(row) > 2 else ""
+                nama_material = row[3] if len(row) > 3 else ""
+                jumlah_value = row[5] if len(row) > 5 else ""
+                satuan = row[6] if len(row) > 6 else ""
+                additional = row[4] if len(row) > 4 else ""
+
+                if len(row) <= 4:
+                    # Newer exports omit the material code column.
+                    nama_material = row[2] if len(row) > 2 else nama_material
+                    jumlah_value = row[3] if len(row) > 3 else jumlah_value
+                    satuan = row[4] if len(row) > 4 else satuan
+                    kode_material = ""
+                    additional = ""
+
+                if not nama_material:
+                    # Some header rows only carry product information.
+                    continue
+
+                material: Material | None = None
+                if kode_material:
+                    material = Material.query.filter_by(kode=kode_material).first()
+
+                if material is None:
+                    material = Material.query.filter_by(nama=nama_material).first()
+
+                if material is None:
+                    material = Material(kode=kode_material or None, nama=nama_material)
+                    db.session.add(material)
+                    db.session.flush()
+                else:
+                    if kode_material and not material.kode:
+                        material.kode = kode_material
+
+                # Update shared material metadata.
+                if satuan:
+                    material.satuan = satuan
+                if additional and not material.jenis:
+                    # The "additional" column stores either a material category
+                    # or the percentage contained in the pack depending on the
+                    # CSV variant. We only copy it when the material has not been
+                    # categorised yet.
+                    material.jenis = additional
+
+                persentase = _parse_float(additional) if "%" in additional else None
+                jumlah_float = _parse_float(jumlah_value)
+
+                komposisi = KomposisiMaterial.query.filter_by(
+                    produk_id=current_produk.id, material_id=material.id
+                ).first()
+                if komposisi is None:
+                    komposisi = KomposisiMaterial(
+                        produk=current_produk,
+                        material=material,
+                    )
+                    db.session.add(komposisi)
+
+                if jumlah_float is not None:
+                    komposisi.jumlah_per_pack = jumlah_float
+                if persentase is not None:
+                    komposisi.persentase = persentase
+                if satuan:
+                    komposisi.satuan = satuan
+
+                material_produk = MaterialProduk.query.filter_by(
+                    produk_id=current_produk.id, material_id=material.id
+                ).first()
+                if material_produk is None:
+                    material_produk = MaterialProduk(
+                        produk=current_produk,
+                        material=material,
+                    )
+                    db.session.add(material_produk)
+
+                if jumlah_float is not None:
+                    material_produk.jumlah = jumlah_float
+                if satuan:
+                    material_produk.satuan = satuan
+
+    except Exception as exc:  # pragma: no cover - defensive error handling
+        current_app.logger.exception("Gagal membaca CSV material: %s", filename)
+        db.session.rollback()
+        return False, f"Gagal membaca file CSV: {exc}"
+
+    return True, "Import material berhasil"


### PR DESCRIPTION
## Summary
- add a Flask application factory that exposes the shared SQLAlchemy instance
- rebuild the models package with the expected ORM entities and convenience exports
- restore the material CSV import helper to populate the database from legacy and new file formats

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e3799be9988321892db181cf08f2da